### PR TITLE
Null value parameter: Description.

### DIFF
--- a/source/templates/starterkit.xml
+++ b/source/templates/starterkit.xml
@@ -117,9 +117,9 @@
       </pnp:SiteCollection>
       <pnp:SiteCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="pnp:TeamSite" ProvisioningId="HR" IsPublic="false"
                           Alias="{parameter:HRALIAS}"  
-                          DisplayName =""
+                          DisplayName ="{parameter:HRALIAS}"
                           Title ="Human Resources"
-                          Description="">
+                          Description="Needs to be filled for team site">
         <pnp:Templates>
           <pnp:ProvisioningTemplateReference ID="COLLAB-TEMPLATE"/>
           <pnp:ProvisioningTemplateReference ID="COLLAB-HR-LOGO-TEMPLATE"/>
@@ -128,9 +128,9 @@
       </pnp:SiteCollection>
       <pnp:SiteCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="pnp:TeamSite" ProvisioningId="MARKETING" IsPublic="false"
                           Alias="{parameter:MARKETINGALIAS}"
-                          DisplayName =""
+                          DisplayName ="{parameter:MARKETINGALIAS}"
                           Title ="Marketing"
-                          Description="">
+                          Description="Needs to be filled for team site">
         <pnp:Templates>
           <pnp:ProvisioningTemplateReference ID="COLLAB-TEMPLATE"/>
           <pnp:ProvisioningTemplateReference ID="COLLAB-MARKETING-LOGO-TEMPLATE"/>


### PR DESCRIPTION
While running script line number:118 and 129 pnp:SiteCollection for team site creation, script is giving error as
Null value error on Apply-PnPTenantTemplate -Path yourstarterkit.pnp 
Parameter: Description

Solution: Update the StaterKit.Xml with adddition of description parameter ,display name of Team Sites and ran powershell script again to convert Xml back to PnP Package.
$kit = Read-PnPTenantTemplate -Path ..\source\templates\starterkit.xml
Save-PnPTenantTemplate -Template $kit -Out yourstarterkit.pnp
