### PR TITLE
People Directory: include * in search to correctly process query

### DIFF
--- a/source/react-people-directory/src/webparts/peopleDirectory/components/PeopleDirectory/PeopleDirectory.tsx
+++ b/source/react-people-directory/src/webparts/peopleDirectory/components/PeopleDirectory/PeopleDirectory.tsx
@@ -95,7 +95,10 @@ export class PeopleDirectory extends React.Component<IPeopleDirectoryProps, IPeo
     // if no search query has been specified, retrieve people whose last name begins with the
     // specified letter. if a search query has been specified, escape any ' (single quotes)
     // by replacing them with two '' (single quotes). Without this, the search query would fail
-    const query: string = searchQuery === null ? `LastName:${index}*` : searchQuery.replace(/'/g, `''`);
+    let query: string = searchQuery === null ? `LastName:${index}*` : searchQuery.replace(/'/g, `''`);
+    if (query.lastIndexOf('*') !== query.length - 1) {
+      query += '*';
+    }
 
     // retrieve information about people using SharePoint People Search
     // sort results ascending by the last name


### PR DESCRIPTION
#### Category
- [ ] Bug Fix
- [ ] New Feature
- Related issues: No

#### What's in this Pull Request?

`*` is automatically added to the search query.
This change allows to return results, for example, in the next situation: user enters **ale** and wants to get Alex
