### PR TITLE
Added required permission request

### DIFF
--- a/source/react-personal-tasks/config/package-solution.json
+++ b/source/react-personal-tasks/config/package-solution.json
@@ -16,6 +16,9 @@
     }, {
       "resource": "Microsoft Graph",
       "scope": "People.Read"
+    }, {
+      "resource": "Microsoft Graph",
+      "scope": "User.ReadBasic.All"
     }]
   },
   "paths": {


### PR DESCRIPTION
#### Category
- [X] Bug Fix
- [ ] New Feature
- Related issues:

#### What's in this Pull Request?
Added required permission request User.ReadBasic.All. The people picker does not work correctly and outputs errors to the console about being unauthorized to https://graph.microsoft.com/v1.0/users/...
User.ReadBasic.All is mentioned as being required by the Graph Toolkit People-Picker component: [People-Picker Graph Permissions](https://docs.microsoft.com/en-us/graph/toolkit/components/people-picker#microsoft-graph-permissions)
