### PR TITLE
Fixing JSON for new PnP Core PowerShell

### DIFF
--- a/source/templates/starterkit.xml
+++ b/source/templates/starterkit.xml
@@ -967,7 +967,7 @@
                       &quot;renderItemsSliderValue&quot;:4,
                       &quot;webId&quot;:&quot;{siteid}&quot;,
                       &quot;siteId&quot;:&quot;{sitecollectionid}&quot;,
-                      &quot;pinnedItems&quot;:[],
+                      &quot;pinnedItems&quot;:[]
                     },
                     &quot;serverProcessedContent&quot;:{
                       &quot;htmlStrings&quot;:{},


### PR DESCRIPTION
The JSON Parser in PnP Core has changed. There was invalid JSON with a trailing comma. I have fixed the staterkit.xml and regenerated the starterkit.pnp file

#### Category
- [x ] Bug Fix
- Related issues: fixes #470 


#### What's in this Pull Request?

Update to the provisioning template, and regenerated starterkit.pnp file. 
