### PR TITLE
Bugfix: Search crashes webpart when its empty

### DIFF
--- a/solution/src/webparts/peopleDirectory/components/PeopleDirectory/PeopleDirectory.tsx
+++ b/solution/src/webparts/peopleDirectory/components/PeopleDirectory/PeopleDirectory.tsx
@@ -95,7 +95,7 @@ export class PeopleDirectory extends React.Component<IPeopleDirectoryProps, IPeo
     // if no search query has been specified, retrieve people whose last name begins with the
     // specified letter. if a search query has been specified, escape any ' (single quotes)
     // by replacing them with two '' (single quotes). Without this, the search query would fail
-    const query: string = searchQuery === null ? `LastName:${index}*` : searchQuery.replace(/'/g, `''`);
+    const query: string = searchQuery === null || searchQuery.length <= 0 ? `LastName:${index}*` : searchQuery.replace(/'/g, `''`);
 
     // retrieve information about people using SharePoint People Search
     // sort results ascending by the last name


### PR DESCRIPTION
When you type something in the search bar, search and get your result then erase and press enter it will crash the webpart.

#### Category
- [ x] Bug Fix
- [ ] New Feature
- Related issues: fixes #X, partially #Y, mentioned in #Z

Fixes bug where searchQuery is empty but not null.